### PR TITLE
Add drag and drop on Candidate cards between statuses on JobShow

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -11,6 +11,8 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
     "@welcome-ui/badge": "^6.0.0",
     "@welcome-ui/box": "^6.0.0",
     "@welcome-ui/card": "^6.0.0",

--- a/assets/src/api/index.ts
+++ b/assets/src/api/index.ts
@@ -3,12 +3,30 @@ type Job = {
   name: string
 }
 
+export enum CandidateStatusesEnum {
+  'new',
+  'interview',
+  'hired',
+  'rejected'
+}
+
+export type CandidateStatus = keyof typeof CandidateStatusesEnum
+
 export type Candidate = {
   id: number
   email: string
-  status: 'new' | 'interview' | 'hired' | 'rejected'
+  status: CandidateStatus
   position: number
 }
+
+export type CandidateParams = {
+  id?: number
+  email?: string
+  status?: CandidateStatus
+  position?: number
+}
+
+// TODO: Use Axios for API calls
 
 export const getJobs = async (): Promise<Job[]> => {
   const response = await fetch(`http://localhost:4000/api/jobs`)
@@ -26,6 +44,20 @@ export const getJob = async (jobId?: string): Promise<Job | null> => {
 export const getCandidates = async (jobId?: string): Promise<Candidate[]> => {
   if (!jobId) return []
   const response = await fetch(`http://localhost:4000/api/jobs/${jobId}/candidates`)
+  const { data } = await response.json()
+  return data
+}
+
+export const updateCandidate = async (jobId?: string, candidateId?: string, candidateParams?: CandidateParams): Promise<Candidate> => {
+  const response = await fetch(`http://localhost:4000/api/jobs/${jobId}/candidates/${candidateId}`, {
+  method: 'PATCH',
+  headers: {
+    'Content-Type': 'application/json', // Ensure the server knows the content type
+  },
+  body: JSON.stringify({
+    candidate: candidateParams
+    })
+  })
   const { data } = await response.json()
   return data
 }

--- a/assets/src/components/Candidate/index.tsx
+++ b/assets/src/components/Candidate/index.tsx
@@ -1,10 +1,47 @@
 import { Card } from '@welcome-ui/card'
 import { Candidate } from '../../api'
+import { useEffect, useRef, useState } from 'react'
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { attachClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { Badge } from '@welcome-ui/badge'
+
 
 function CandidateCard({ candidate }: { candidate: Candidate }) {
+  const ref = useRef(null);
+  const [dragging, setDragging] = useState<boolean>(false);
+
+  useEffect(() => {
+    const candidateCard = ref.current;
+    if (!candidateCard) return
+
+    return combine(
+      draggable({
+        element: candidateCard,
+        getInitialData: () => ({ candidate }),
+        onDragStart: () => setDragging(true),
+        onDrop: () => setDragging(false),
+      }),
+      dropTargetForElements({
+        element: candidateCard,
+        getData: ({ input, element }) => {
+          return attachClosestEdge(candidate, {
+            input: input,
+            element: element,
+            allowedEdges: ["top", "bottom"]
+          })
+        }
+      })
+    )
+
+  }, [candidate]);
+
   return (
-    <Card mb={10}>
-      <Card.Body>{candidate.email}</Card.Body>
+    <Card mb={10} ref={ref} opacity={dragging ? 0.4 : 1}>
+      <Card.Body>
+        <Badge>{candidate.position}</Badge>
+        {candidate.email}
+      </Card.Body>
     </Card>
   )
 }

--- a/assets/src/components/CandidateBox/index.tsx
+++ b/assets/src/components/CandidateBox/index.tsx
@@ -1,0 +1,37 @@
+import { Box } from '@welcome-ui/box'
+import { useEffect, useRef, useState } from 'react'
+import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
+import { CandidateStatus } from '../../api';
+
+function CandidateBox({ columnId, children }: { columnId: CandidateStatus, children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isDraggedOver, setIsDraggedOver] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    return dropTargetForElements({
+      element: el,
+      getData: () => ({ columnId }),
+      onDragEnter: () => setIsDraggedOver(true),
+      onDragLeave: () => setIsDraggedOver(false),
+      onDrop: () => setIsDraggedOver(false),
+    });
+  }, [columnId]);
+
+  return (
+    <Box
+      w={300}
+      border={1}
+      backgroundColor={isDraggedOver ? "yellow-10" : "white"}
+      borderColor={isDraggedOver ? "yellow-30" : "neutral-30"}
+      borderRadius="md"
+      overflow="hidden"
+      ref={ref}
+    >
+      {children}
+    </Box>
+  );
+}
+export default CandidateBox

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -1,5 +1,5 @@
-import { useQuery } from 'react-query'
-import { getCandidates, getJob, getJobs } from '../api'
+import { useMutation, useQuery, useQueryClient } from 'react-query'
+import { getCandidates, getJob, getJobs, updateCandidate, CandidateParams} from '../api'
 
 export const useJobs = () => {
   const { isLoading, error, data } = useQuery({
@@ -28,4 +28,17 @@ export const useCandidates = (jobId?: string) => {
   })
 
   return { isLoading, error, candidates: data }
+}
+
+export const useUpdateCandidate = (jobId?: string) => {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: ({ candidateId, candidate }: { candidateId: string, candidate: CandidateParams }) => 
+      updateCandidate(jobId, candidateId, candidate),
+    onSuccess: () => {
+      // Invalidate and refetch candidates list after successful update
+      queryClient.invalidateQueries(['candidates', jobId])
+    }
+  })
 }

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -15,6 +15,23 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@atlaskit/pragmatic-drag-and-drop-hitbox@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz#fcce42f5e2c5a26007f4422397acad29608d3784"
+  integrity sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==
+  dependencies:
+    "@atlaskit/pragmatic-drag-and-drop" "^1.1.0"
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/pragmatic-drag-and-drop@^1.1.0", "@atlaskit/pragmatic-drag-and-drop@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.4.0.tgz#0e3441b2549adcc41e0cacac33d33bc71952f9f8"
+  integrity sha512-qRY3PTJIcxfl/QB8Gwswz+BRvlmgAC5pB+J2hL6dkIxgqAgVwOhAamMUKsrOcFU/axG2Q7RbNs1xfoLKDuhoPg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    raf-schd "^4.0.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.0.tgz#9374b5cd068d128dac0b94ff482594273b1c2815"
@@ -987,7 +1004,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.25.9"
     "@babel/plugin-transform-typescript" "^7.25.9"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.23.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.23.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -2370,6 +2387,11 @@ big-integer@^1.6.16:
   version "1.6.52"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
   integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
+
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -4523,6 +4545,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+raf-schd@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
 
 ramda@^0.30.1:
   version "0.30.1"

--- a/lib/wttj/candidates.ex
+++ b/lib/wttj/candidates.ex
@@ -3,10 +3,14 @@ defmodule Wttj.Candidates do
   The Candidates context.
   """
 
-  import Ecto.Query, warn: false
-  alias Wttj.Repo
+  require Logger
 
+  import Ecto.Query, warn: false
+
+  alias Ecto.Changeset
+  alias Wttj.Repo
   alias Wttj.Candidates.Candidate
+  alias Wttj.Jobs
 
   @doc """
   Returns the list of candidates.
@@ -69,9 +73,37 @@ defmodule Wttj.Candidates do
 
   """
   def update_candidate(%Candidate{} = candidate, attrs) do
-    candidate
-    |> Candidate.changeset(attrs)
-    |> Repo.update()
+    candidate_changeset = Candidate.changeset(candidate, attrs)
+
+    if Changeset.changed?(candidate_changeset, :status) or
+         Changeset.changed?(candidate_changeset, :position) do
+      update_and_reorder_candidates(candidate, candidate_changeset)
+    else
+      Repo.update(candidate_changeset)
+    end
+  end
+
+  defp update_and_reorder_candidates(candidate, candidate_changeset) do
+    Logger.debug("Updating candidate #{candidate.id} with reordering")
+
+    Repo.transaction(fn ->
+      # reordering is done after the update, position is temporarily
+      # set to -1 to avoid potential unique key constraint error
+      case candidate_changeset |> Changeset.put_change(:position, -1) |> Repo.update() do
+        {:ok, updated_candidate} ->
+          handle_candidate_reordering!(
+            updated_candidate,
+            candidate,
+            candidate_changeset
+          )
+
+          # getting the freshest version of the candidate after the reordering
+          get_candidate!(candidate.job_id, updated_candidate.id)
+
+        {:error, changeset} ->
+          Repo.rollback(changeset)
+      end
+    end)
   end
 
   @doc """
@@ -85,5 +117,100 @@ defmodule Wttj.Candidates do
   """
   def change_candidate(%Candidate{} = candidate, attrs \\ %{}) do
     Candidate.changeset(candidate, attrs)
+  end
+
+  defp evaluate_new_position(%Ecto.Changeset{} = candidate_changeset) do
+    status = Changeset.get_field(candidate_changeset, :status)
+    job_id = Changeset.get_field(candidate_changeset, :job_id)
+    max_position = Jobs.count_candidates(job_id, [status])
+
+    # ensure that the new position is not greater than the max position and not less than 0
+    new_position =
+      candidate_changeset
+      |> Changeset.get_field(:position)
+      |> min(max_position)
+      |> max(0)
+
+    new_position
+  end
+
+  defp handle_candidate_reordering!(
+         %Candidate{} = updated_candidate,
+         %Candidate{} = candidate,
+         candidate_changeset
+       ) do
+    new_position = evaluate_new_position(candidate_changeset)
+
+    Logger.debug(
+      "New candidate position `#{new_position}` for status `#{updated_candidate.status}`"
+    )
+
+    # we reorder candidates within the previous status only if the status has changed
+    if Changeset.changed?(candidate_changeset, :status) do
+      Logger.debug("Reordering candidates from previous status `#{candidate.status}`")
+      reorder_candidates_and_update_positions!(candidate.job_id, candidate.status)
+    end
+
+    # we reorder candidates within the current status a after update if the status or position has changed
+    Logger.debug("Reordering candidates on current status `#{updated_candidate.status}`")
+
+    reorder_candidates_and_update_positions!(
+      updated_candidate.job_id,
+      updated_candidate.status,
+      updated_candidate,
+      new_position
+    )
+  end
+
+  defp reorder_candidates_and_update_positions!(
+         job_id,
+         status,
+         candidate_to_move \\ nil,
+         new_position \\ nil
+       ) do
+    # Fetch all candidates in the specified job and status
+    candidates =
+      from(c in Candidate)
+      |> where([c], c.job_id == ^job_id and c.status == ^status)
+      |> exclude_updated_candidate(candidate_to_move)
+      |> order_by([c], asc: c.position)
+      |> Repo.all()
+
+    # Insert the updated candidate if provided, at its position in the list
+    candidates =
+      if not is_nil(candidate_to_move) and not is_nil(new_position) do
+        List.insert_at(candidates, new_position, candidate_to_move)
+      else
+        candidates
+      end
+
+    # Reorder positions
+    candidates
+    |> Enum.with_index()
+    # Rejecting unchanged candidates to avoid useless update (except if it's the candidate to move)
+    |> Enum.reject(fn {candidate, index} ->
+      if is_nil(candidate_to_move) or candidate.id != candidate_to_move.id do
+        candidate.position == index
+      end
+    end)
+    |> Enum.map(fn {candidate, index} ->
+      candidate
+      |> Map.from_struct()
+      |> Map.delete(:__meta__)
+      |> Map.put(:position, index)
+    end)
+    |> then(
+      &Repo.insert_all(Candidate, &1,
+        on_conflict: {:replace, [:position]},
+        conflict_target: [:id]
+      )
+    )
+  end
+
+  # Helper to exclude the updated candidate if provided
+  defp exclude_updated_candidate(query, nil), do: query
+
+  defp exclude_updated_candidate(query, %Candidate{id: id}) do
+    where(query, [c], c.id != ^id)
   end
 end

--- a/lib/wttj/jobs.ex
+++ b/lib/wttj/jobs.ex
@@ -7,6 +7,7 @@ defmodule Wttj.Jobs do
   alias Wttj.Repo
 
   alias Wttj.Jobs.Job
+  alias Wttj.Candidates.Candidate
 
   @doc """
   Returns the list of jobs.
@@ -101,4 +102,21 @@ defmodule Wttj.Jobs do
   def change_job(%Job{} = job, attrs \\ %{}) do
     Job.changeset(job, attrs)
   end
+
+  def count_candidates(job_or_id, statuses \\ [])
+
+  def count_candidates(%Job{} = job, statuses), do: count_candidates(job.id, statuses)
+
+  def count_candidates(job_id, statuses) do
+    Candidate
+    |> from()
+    |> where([c], c.job_id == ^job_id)
+    |> where_candidate_within_statuses(statuses)
+    |> Repo.aggregate(:count)
+  end
+
+  defp where_candidate_within_statuses(query, nil), do: query
+
+  defp where_candidate_within_statuses(query, statuses),
+    do: where(query, [c], c.status in ^statuses)
 end

--- a/priv/repo/migrations/20250106103120_change_candidates_unique_index.exs
+++ b/priv/repo/migrations/20250106103120_change_candidates_unique_index.exs
@@ -1,0 +1,8 @@
+defmodule Wttj.Repo.Migrations.AddCandidatesUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:candidates, [:job_id, :position, :status])
+    create unique_index(:candidates, [:id, :job_id, :position, :status])
+  end
+end

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -39,7 +39,8 @@ defmodule Wttj.CandidatesTest do
       assert {:ok, %Candidate{} = candidate} =
                Candidates.update_candidate(candidate, update_attrs)
 
-      assert candidate.position == 43
+      # position is evaluated to 0 since there is only one candidate if this test
+      assert candidate.position == 0
       assert candidate.status == :rejected
       assert candidate.email == email
     end

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -45,6 +45,106 @@ defmodule Wttj.CandidatesTest do
       assert candidate.email == email
     end
 
+    test "update_candidate/2 maintains correct position ordering when moving candidate up", %{
+      job1: job1
+    } do
+      candidate1 = candidate_fixture(%{job_id: job1.id, status: :new, position: 0})
+      candidate2 = candidate_fixture(%{job_id: job1.id, status: :new, position: 1})
+      candidate3 = candidate_fixture(%{job_id: job1.id, status: :new, position: 2})
+
+      assert {:ok, candidate3} = Candidates.update_candidate(candidate3, %{position: 0})
+
+      [first, second, third] =
+        job1.id |> Candidates.list_candidates() |> Enum.sort_by(& &1.position)
+
+      assert first.id == candidate3.id
+      assert first.position == 0
+      assert second.id == candidate1.id
+      assert second.position == 1
+      assert third.id == candidate2.id
+      assert third.position == 2
+    end
+
+    test "update_candidate/2 maintains correct position ordering when moving candidate down", %{
+      job1: job1
+    } do
+      candidate1 = candidate_fixture(%{job_id: job1.id, status: :new, position: 0})
+      candidate2 = candidate_fixture(%{job_id: job1.id, status: :new, position: 1})
+      candidate3 = candidate_fixture(%{job_id: job1.id, status: :new, position: 2})
+
+      assert {:ok, candidate1} = Candidates.update_candidate(candidate1, %{position: 2})
+
+      [first, second, third] =
+        job1.id |> Candidates.list_candidates() |> Enum.sort_by(& &1.position)
+
+      assert first.id == candidate2.id
+      assert first.position == 0
+      assert second.id == candidate3.id
+      assert second.position == 1
+      assert third.id == candidate1.id
+      assert third.position == 2
+    end
+
+    test "update_candidate/2 ajdust position ordering when moving candidate in between",
+         %{
+           job1: job1
+         } do
+      candidate1 = candidate_fixture(%{job_id: job1.id, status: :new, position: 0})
+      candidate2 = candidate_fixture(%{job_id: job1.id, status: :new, position: 1})
+      candidate3 = candidate_fixture(%{job_id: job1.id, status: :new, position: 2})
+
+      assert {:ok, candidate1} = Candidates.update_candidate(candidate1, %{position: 1})
+
+      [first, second, third] =
+        job1.id |> Candidates.list_candidates() |> Enum.sort_by(& &1.position)
+
+      assert first.id == candidate2.id
+      assert first.position == 0
+      assert second.id == candidate1.id
+      assert second.position == 1
+      assert third.id == candidate3.id
+      assert third.position == 2
+    end
+
+    test "update_candidate/2 handles status changes and position", %{job1: job1} do
+      candidate1 = candidate_fixture(%{job_id: job1.id, status: :new, position: 0})
+
+      candidate2 = candidate_fixture(%{job_id: job1.id, status: :interview, position: 0})
+      candidate3 = candidate_fixture(%{job_id: job1.id, status: :interview, position: 1})
+
+      assert {:ok, candidate1} =
+               Candidates.update_candidate(candidate1, %{position: 1, status: :interview})
+
+      [first, second, third] =
+        job1.id |> Candidates.list_candidates() |> Enum.sort_by(& &1.position)
+
+      assert first.id == candidate2.id
+      assert first.position == 0
+      assert first.status == :interview
+
+      assert second.id == candidate1.id
+      assert second.position == 1
+      assert second.status == :interview
+
+      assert third.id == candidate3.id
+      assert third.position == 2
+      assert third.status == :interview
+    end
+
+    test "update_candidate/2 with out of bound position is adapting to existing number of candidates",
+         %{job1: job1} do
+      candidate = candidate_fixture(%{job_id: job1.id, status: :new, position: 0})
+
+      candidate_fixture(%{job_id: job1.id, status: :interview, position: 0})
+      candidate_fixture(%{job_id: job1.id, status: :interview, position: 1})
+
+      assert {:ok, %{position: 0}} =
+               Candidates.update_candidate(candidate, %{status: :interview, position: -1})
+
+      assert {:ok, %{position: 2}} =
+               Candidates.update_candidate(candidate, %{status: :interview, position: 999})
+    end
+
     test "update_candidate/2 with invalid data returns error changeset", %{job1: job1} do
       candidate = candidate_fixture(%{job_id: job1.id})
       assert {:error, %Ecto.Changeset{}} = Candidates.update_candidate(candidate, @invalid_attrs)

--- a/test/wttj_web/controllers/candidate_controller_test.exs
+++ b/test/wttj_web/controllers/candidate_controller_test.exs
@@ -42,7 +42,7 @@ defmodule WttjWeb.CandidateControllerTest do
       assert %{
                "id" => ^id,
                "email" => ^email,
-               "position" => 43,
+               "position" => 0,
                "status" => "interview"
              } = json_response(conn, 200)["data"]
     end


### PR DESCRIPTION
### Frontend

- Add new dependencies to manage drag and drop : 
  - https://www.npmjs.com/package/@atlaskit/pragmatic-drag-and-drop
  - https://www.npmjs.com/package/@atlaskit/pragmatic-drag-and-drop-hitbox
- Add new component CandidateBox to have better hierarchy between components and improve drag and drop management
- Add new mutation hook to manage API updateCandidate and candidates list changes
- Minor refactor around variables names and defined types

### Backend

- Enhance Update Candidate endpoint : 
   - update_candidate/2 now manage position re-ordering when position or status are updated,
     it is mandatory to keep track of frontend modifications when moving candidates through status with drag and drop